### PR TITLE
Populate library.properties url field

### DIFF
--- a/controlrgb/library.properties
+++ b/controlrgb/library.properties
@@ -5,5 +5,5 @@ maintainer=Eduardo Cáceres de la Calle <edcaceres95@hotmail.com>
 sentence= Controls a RGB
 paragraph=This library allows an Arduino board to control a RGB, sending different voltages to each LED.
 category=Display
-url=*
+url=https://github.com/eduherminio/controlrgb
 architectures=*


### PR DESCRIPTION
A empty url field results in an apparently clickable "More info" link in Library Manager that does nothing.